### PR TITLE
Avoid printing long Tenderly URLs

### DIFF
--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -109,14 +109,19 @@ abstract contract Simulator is CommonBase {
             vm.toString(block.chainid),
             "&contractAddress=",
             vm.toString(_to),
-            "&rawFunctionInput=",
-            vm.toString(_data),
             "&from=",
             vm.toString(_from),
             "&stateOverrides=",
             stateOverrides
         );
-
-        console.log(str);
+        if (bytes(str).length + _data.length * 2 > 7980) {
+            // tenderly's nginx has issues with long URLs, so print the raw input data separately
+            str = string.concat(str, "\nInsert the following hex into the 'Raw input data' field:");
+            console.log(str);
+            console.log(vm.toString(_data));
+        } else {
+            str = string.concat(str, "&rawFunctionInput=", vm.toString(_data));
+            console.log(str);
+        }
     }
 }


### PR DESCRIPTION
Tenderly's nginx has a URI limit of somewhere just over 8000 characters. This PR removes the `rawFunctionInput` query parameter if the URI is too long, and instead prints it separately for the user to copy/paste.