### PR TITLE
feat: override safe nonce and verify signatures

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -26,6 +26,13 @@ abstract contract MultisigBase is Simulator {
 
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         uint256 nonce = safe.nonce();
+        console.log("Safe current nonce:", nonce);
+
+        uint256 nonceOverride = vm.envUint("NONCE");
+        if (nonceOverride > nonce) {
+            nonce = nonceOverride;
+            console.log("Creating transaction with nonce:", nonce);
+        }
 
         return safe.encodeTransactionData({
             to: address(multicall),

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -28,7 +28,7 @@ abstract contract MultisigBase is Simulator {
         uint256 nonce = safe.nonce();
         console.log("Safe current nonce:", nonce);
 
-        uint256 nonceOverride = vm.envUint("NONCE");
+        uint256 nonceOverride = vm.envUint("SAFE_NONCE");
         if (nonceOverride > nonce) {
             nonce = nonceOverride;
             console.log("Creating transaction with nonce:", nonce);

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -59,6 +59,16 @@ abstract contract MultisigBuilder is MultisigBase {
     /**
      * Step 2
      * ======
+     * Verify the signatures generated from step 1 are valid.
+     * This allow transactions to be pre-signed and stored safely before execution.
+     */
+    function verify(bytes memory _signatures) public view {
+        _checkSignatures(_ownerSafe(), _buildCalls(), _signatures);
+    }
+
+    /**
+     * Step 3
+     * ======
      * Execute the transaction. This method should be called by the final member of the multisig
      * that will execute the transaction. Signatures from step 1 are required.
      *


### PR DESCRIPTION
This change adds a new environment variable called `SAFE_NONCE` which allow callers to override the Safe contract nonce.

This is useful when crafting future transactions ahead of time and collecting signatures.

It also provides a new `function verify(bytes memory _signatures)` to make sure the collected signatures are valid to execute the transaction.

It is intended to work as:
1. Maintainer craft a transaction ahead of time
2. Multiple signer parties are contacted and sign the transaction offline
3. Maintainer collect and verify the presigned transactions
4. Transaction with signatures are stored safely for later execution