### PR TITLE
fix: check optional environment variable as string before parsing into uint256

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -28,9 +28,8 @@ abstract contract MultisigBase is Simulator {
         uint256 nonce = safe.nonce();
         console.log("Safe current nonce:", nonce);
 
-        uint256 nonceOverride = vm.envUint("SAFE_NONCE");
-        if (nonceOverride > nonce) {
-            nonce = nonceOverride;
+        if (bytes(vm.envString("SAFE_NONCE")).length > 0) {
+            nonce = vm.envUint("SAFE_NONCE");
             console.log("Creating transaction with nonce:", nonce);
         }
 


### PR DESCRIPTION
I noticed when the env `SAFE_NONCE` was missing, the script failed because it couldn't convert an empty string("") into uint256.

This change checks the value of the env var before attempting to parse it.