### PR TITLE
fix: safe_nonce env shouldnt be required

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -28,7 +28,7 @@ abstract contract MultisigBase is Simulator {
         uint256 nonce = safe.nonce();
         console.log("Safe current nonce:", nonce);
 
-        if (bytes(vm.envString("SAFE_NONCE")).length > 0) {
+        if (bytes(vm.envOr("SAFE_NONCE", "")).length > 0) {
             nonce = vm.envUint("SAFE_NONCE");
             console.log("Creating transaction with nonce:", nonce);
         }


### PR DESCRIPTION
When SAFE_NONCE is not set, the script fails with
```
    ├─ [0] VM::envString("SAFE_NONCE") [staticcall]
    │   └─ ← environment variable "SAFE_NONCE" not found
    └─ ← environment variable "SAFE_NONCE" not found
```

This change replaces `envString` to `envOr` defaulting to an empty string.
