### PR TITLE
Flexible version for universal scripts

### DIFF
--- a/script/deploy/l1/tests/TestDeposits.s.sol
+++ b/script/deploy/l1/tests/TestDeposits.s.sol
@@ -7,8 +7,8 @@ import "forge-std/Script.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import {ERC721PresetMinterPauserAutoId} from "@openzeppelin/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol";
 
-import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
-import {L1ERC721Bridge} from "@eth-optimism-bedrock/src/L1/L1ERC721Bridge.sol";
+import {L1StandardBridge} from "@eth-optimism-bedrock/contracts/L1/L1StandardBridge.sol";
+import {L1ERC721Bridge} from "@eth-optimism-bedrock/contracts/L1/L1ERC721Bridge.sol";
 
 // Deposits funds to Base Mainnet to test its functionality
 contract DeployTestContracts is Script {

--- a/script/deploy/l2/tests/DeployTestTokenContracts.s.sol
+++ b/script/deploy/l2/tests/DeployTestTokenContracts.s.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.15;
 import "forge-std/console.sol";
 import "forge-std/Script.sol";
 
-import {Predeploys} from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
-import {OptimismMintableERC20Factory} from "@eth-optimism-bedrock/src/universal/OptimismMintableERC20Factory.sol";
-import {OptimismMintableERC721Factory} from "@eth-optimism-bedrock/src/universal/OptimismMintableERC721Factory.sol";
+import {Predeploys} from "@eth-optimism-bedrock/contracts/libraries/Predeploys.sol";
+import {OptimismMintableERC20Factory} from "@eth-optimism-bedrock/contracts/universal/OptimismMintableERC20Factory.sol";
+import {OptimismMintableERC721Factory} from "@eth-optimism-bedrock/contracts/universal/OptimismMintableERC721Factory.sol";
 
 // Deploys test token contracts on L2 to test Base Mainnet functionality
 contract DeployTestTokenContracts is Script {

--- a/script/deploy/l2/tests/TestWithdraw.s.sol
+++ b/script/deploy/l2/tests/TestWithdraw.s.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.15;
 import "forge-std/console.sol";
 import "forge-std/Script.sol";
 
-import {Predeploys} from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
-import {L2StandardBridge} from "@eth-optimism-bedrock/src/L2/L2StandardBridge.sol";
-import {L2ERC721Bridge} from "@eth-optimism-bedrock/src/L2/L2ERC721Bridge.sol";
+import {Predeploys} from "@eth-optimism-bedrock/contracts/libraries/Predeploys.sol";
+import {L2StandardBridge} from "@eth-optimism-bedrock/contracts/L2/L2StandardBridge.sol";
+import {L2ERC721Bridge} from "@eth-optimism-bedrock/contracts/L2/L2ERC721Bridge.sol";
 
 // Withdraws tokens from L2 to L1 to test Base Mainnet's bridging functionality
 contract TestWithdraw is Script {

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {console} from "forge-std/console.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "./MultisigBase.sol";
 

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "./MultisigBase.sol";
 

--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import { console } from "forge-std/console.sol";
 import { CommonBase } from "forge-std/Base.sol";

--- a/src/revenue-share/BalanceTracker.sol
+++ b/src/revenue-share/BalanceTracker.sol
@@ -6,7 +6,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ReentrancyGuardUpgradeable } 
     from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import { SafeCall } from "@eth-optimism-bedrock/src/libraries/SafeCall.sol";
+import { SafeCall } from "@eth-optimism-bedrock/contracts/libraries/SafeCall.sol";
 
 /**
  * @title BalanceTracker

--- a/src/revenue-share/FeeDisburser.sol
+++ b/src/revenue-share/FeeDisburser.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.15;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-import { L2StandardBridge } from "@eth-optimism-bedrock/src/L2/L2StandardBridge.sol";
-import { FeeVault } from "@eth-optimism-bedrock/src/universal/FeeVault.sol";
-import { Predeploys } from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
-import { SafeCall } from "@eth-optimism-bedrock/src/libraries/SafeCall.sol";
+import { L2StandardBridge } from "@eth-optimism-bedrock/contracts/L2/L2StandardBridge.sol";
+import { FeeVault } from "@eth-optimism-bedrock/contracts/universal/FeeVault.sol";
+import { Predeploys } from "@eth-optimism-bedrock/contracts/libraries/Predeploys.sol";
+import { SafeCall } from "@eth-optimism-bedrock/contracts/libraries/SafeCall.sol";
 
 /**
  * @title FeeDisburser

--- a/test/Challenger1of2.t.sol
+++ b/test/Challenger1of2.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.15;
 import {console} from "forge-std/console.sol";
 import { Test, StdUtils } from "forge-std/Test.sol";
 
-import { L2OutputOracle } from "@eth-optimism-bedrock/src/L1/L2OutputOracle.sol";
-import { ProxyAdmin } from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
-import { Proxy } from "@eth-optimism-bedrock/src/universal/Proxy.sol";
+import { L2OutputOracle } from "@eth-optimism-bedrock/contracts/L1/L2OutputOracle.sol";
+import { ProxyAdmin } from "@eth-optimism-bedrock/contracts/universal/ProxyAdmin.sol";
+import { Proxy } from "@eth-optimism-bedrock/contracts/universal/Proxy.sol";
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Challenger1of2 } from "src/Challenger1of2.sol";

--- a/test/fee-vault-fixes/e2e/FeeVault.t.sol
+++ b/test/fee-vault-fixes/e2e/FeeVault.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { CommonTest } from "test/CommonTest.t.sol";
-import { Predeploys } from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
-import { Proxy } from "@eth-optimism-bedrock/src/universal/Proxy.sol";
-import { L1FeeVault as L1FeeVault_Final, FeeVault as FeeVault_Final } from "@eth-optimism-bedrock/src/L2/L1FeeVault.sol";
+import { Predeploys } from "@eth-optimism-bedrock/contracts/libraries/Predeploys.sol";
+import { Proxy } from "@eth-optimism-bedrock/contracts/universal/Proxy.sol";
+import { L1FeeVault as L1FeeVault_Final, FeeVault as FeeVault_Final } from "@eth-optimism-bedrock/contracts/L2/L1FeeVault.sol";
 import { FeeVault as FeeVault_Fix } from "src/fee-vault-fixes/FeeVault.sol";
 
 contract L1FeeVaultTest is CommonTest {

--- a/test/revenue-share/BalanceTracker.t.sol
+++ b/test/revenue-share/BalanceTracker.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/CommonTest.t.sol";
 import { ReenterProcessFees } from "test/revenue-share/mocks/ReenterProcessFees.sol";
 
-import { Proxy } from "@eth-optimism-bedrock/src/universal/Proxy.sol";
+import { Proxy } from "@eth-optimism-bedrock/contracts/universal/Proxy.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 import { BalanceTracker } from "src/revenue-share/BalanceTracker.sol";

--- a/test/revenue-share/FeeDisburser.t.sol
+++ b/test/revenue-share/FeeDisburser.t.sol
@@ -9,11 +9,11 @@ import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/trans
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-import { L2StandardBridge } from "@eth-optimism-bedrock/src/L2/L2StandardBridge.sol";
-import { SequencerFeeVault, FeeVault } from "@eth-optimism-bedrock/src/L2/SequencerFeeVault.sol";
-import { BaseFeeVault } from "@eth-optimism-bedrock/src/L2/BaseFeeVault.sol";
-import { L1FeeVault } from "@eth-optimism-bedrock/src/L2/L1FeeVault.sol";
-import { Predeploys } from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
+import { L2StandardBridge } from "@eth-optimism-bedrock/contracts/L2/L2StandardBridge.sol";
+import { SequencerFeeVault, FeeVault } from "@eth-optimism-bedrock/contracts/L2/SequencerFeeVault.sol";
+import { BaseFeeVault } from "@eth-optimism-bedrock/contracts/L2/BaseFeeVault.sol";
+import { L1FeeVault } from "@eth-optimism-bedrock/contracts/L2/L1FeeVault.sol";
+import { Predeploys } from "@eth-optimism-bedrock/contracts/libraries/Predeploys.sol";
 
 import { FeeDisburser } from "src/revenue-share/FeeDisburser.sol";
 

--- a/test/revenue-share/mocks/FeeVaultRevert.sol
+++ b/test/revenue-share/mocks/FeeVaultRevert.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { FeeVault } from "@eth-optimism-bedrock/src/universal/FeeVault.sol";
+import { FeeVault } from "@eth-optimism-bedrock/contracts/universal/FeeVault.sol";
 
 contract FeeVaultRevert {
     address internal immutable _RECIPIENT;


### PR DESCRIPTION
Allow for more recent solc version for Multisig builder scripts, since there's no reason really to restrict it to only 0.8.15.

Also fix some dependency path issues that came up since Optimism's repo structure changed