### PR TITLE
Add new hooks to Multisig tooling for better simulation control 

### DIFF
--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -113,7 +113,7 @@ abstract contract MultisigBuilder is MultisigBase {
         return success;
     }
 
-    function _simulateForSigner(address _safe, IMulticall3.Call3[] memory _calls) internal view {
+    function _simulateForSigner(address _safe, IMulticall3.Call3[] memory _calls) internal virtual view {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (_calls));
 

--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -85,36 +85,46 @@ abstract contract Simulator is CommonBase {
     }
 
     function overrideSafeThresholdOwnerAndNonce(address _safe, address _owner, uint256 _nonce) public view returns (SimulationStateOverride memory) {
-        SimulationStorageOverride[] memory overrides;
-
         // get the nonce and check if we need to override it
         (, bytes memory nonceBytes) = _safe.staticcall(abi.encodeWithSignature("nonce()"));
         uint256 nonce = abi.decode(nonceBytes, (uint256));
 
         // set the threshold (slot 4) to 1
-        overrides[0] = SimulationStorageOverride({
+        SimulationStorageOverride memory thresholdOverride = SimulationStorageOverride({
             key: bytes32(uint256(0x4)),
             value: bytes32(uint256(0x1))
         });
 
         // set the ownerCount (slot 3) to 1
-        overrides[1] = SimulationStorageOverride({
+        SimulationStorageOverride memory ownerCountOverride = SimulationStorageOverride({
             key: bytes32(uint256(0x3)),
             value: bytes32(uint256(0x1))
         });
 
         // override the owner mapping (slot 2), which requires two key/value pairs: { 0x1: _owner, _owner: 0x1 }
-        overrides[2] = SimulationStorageOverride({
+        SimulationStorageOverride memory ownerMappingOverride = SimulationStorageOverride({
             key: bytes32(0xe90b7bceb6e7df5418fb78d8ee546e97c83a08bbccc01a0644d599ccd2a7c2e0), // keccak256(1 || 2)
             value: bytes32(uint256(uint160(_owner)))
         });
-        overrides[3] = SimulationStorageOverride({
+        SimulationStorageOverride memory isOwnerOverride = SimulationStorageOverride({
             key: keccak256(abi.encode(_owner, uint256(2))),
             value: bytes32(uint256(0x1))
         });
         
-        if (nonce != _nonce) {
-            // need to override the nonce
+        SimulationStorageOverride[] memory overrides;
+        if (nonce == _nonce) {
+            overrides = new SimulationStorageOverride[](4);
+            overrides[0] = thresholdOverride;
+            overrides[1] = ownerCountOverride;
+            overrides[2] = ownerMappingOverride;
+            overrides[3] = isOwnerOverride;
+        }
+        else {
+            overrides = new SimulationStorageOverride[](5);
+            overrides[0] = thresholdOverride;
+            overrides[1] = ownerCountOverride;
+            overrides[2] = ownerMappingOverride;
+            overrides[3] = isOwnerOverride;
             overrides[4] = SimulationStorageOverride({key: bytes32(uint256(0x5)), value: bytes32(_nonce)});
         }
 

--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -36,6 +36,9 @@ abstract contract Simulator is CommonBase {
         return overrideSafeThresholdOwnerAndNonce(_safe, _owner, UINT256_MAX);
     }
 
+    // Always updates the threshhold to 1
+    // Will update the `_owner` if `_owner != address(0)`
+    // Will update the `_nonce` if `_nonce !=UINT256_MAX` 
     function overrideSafeThresholdOwnerAndNonce(address _safe, address _owner, uint256 _nonce) public view returns (SimulationStateOverride memory) {
         // get the nonce and check if we need to override it
         (, bytes memory nonceBytes) = _safe.staticcall(abi.encodeWithSignature("nonce()"));
@@ -71,8 +74,8 @@ abstract contract Simulator is CommonBase {
             overrides[2] = ownerMappingOverride;
             overrides[3] = isOwnerOverride;
         }
-        else if (_owner == address(0)) { // Don't update owner 
-            overrides = new SimulationStorageOverride[](5);
+        else if (_owner == address(0)) { // Don't update owner
+            overrides = new SimulationStorageOverride[](3);
             overrides[0] = thresholdOverride;
             overrides[1] = isOwnerOverride;
             overrides[2] = SimulationStorageOverride({key: bytes32(uint256(0x5)), value: bytes32(_nonce)});

--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -115,7 +115,7 @@ abstract contract Simulator is CommonBase {
         
         if (nonce != _nonce) {
             // need to override the nonce
-            overrides[5] = SimulationStorageOverride({key: bytes32(uint256(0x5)), value: bytes32(_nonce)});
+            overrides[4] = SimulationStorageOverride({key: bytes32(uint256(0x5)), value: bytes32(_nonce)});
         }
 
         return SimulationStateOverride({


### PR DESCRIPTION
With some upcoming config changes, we need more granular control over the Multisig signature simulations. This PR implements two changes: 

1. The `_simulateForSigner` method is now `virtual` so that an inheriting contract can overwrite its logic if need be. 
2. New method `overrideSafeThresholdOwnerAndNonce` has been added to give additonal flexibility in overwriting the safe's state for simulation calls.