### PR TITLE
Add overrides hook 

### DIFF
--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -117,18 +117,8 @@ abstract contract MultisigBuilder is MultisigBase {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (_calls));
 
-        uint256 _nonce = safe.nonce();
-        console.log("Safe current nonce:", _nonce);
-
-        // workaround to check if the SAFE_NONCE env var is present
-        try vm.envUint("SAFE_NONCE") {
-            _nonce = vm.envUint("SAFE_NONCE");
-            console.log("Creating transaction with nonce:", _nonce);
-        }
-        catch {}
-
         SimulationStateOverride[] memory overrides = new SimulationStateOverride[](1);
-        overrides[0] = _addOverrides(_safe, address(0), _nonce);
+        overrides[0] = _addOverrides(_safe);
 
         logSimulationLink({
             _to: _safe,
@@ -158,7 +148,17 @@ abstract contract MultisigBuilder is MultisigBase {
     // will not be reflected in the prod execution. 
     // This particular implementation can be overwritten by an inheriting script. The 
     // default logic is vestigial for backwards compatibility. 
-    function _addOverrides(address _safe, address, uint256 _nonce) internal virtual view returns (SimulationStateOverride memory) {
+    function _addOverrides(address _safe) internal virtual view returns (SimulationStateOverride memory) {
+        IGnosisSafe safe = IGnosisSafe(payable(_safe));
+        uint256 _nonce = safe.nonce();
+        console.log("Safe current nonce:", _nonce);
+
+        // workaround to check if the SAFE_NONCE env var is present
+        try vm.envUint("SAFE_NONCE") {
+            _nonce = vm.envUint("SAFE_NONCE");
+            console.log("Creating transaction with nonce:", _nonce);
+        }
+        catch {}
         return overrideSafeThresholdAndNonce(_safe, _nonce);
     }
 }

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -128,11 +128,7 @@ abstract contract MultisigBuilder is MultisigBase {
         catch {}
 
         SimulationStateOverride[] memory overrides = new SimulationStateOverride[](1);
-        // The state change simulation sets the multisig threshold to 1 in the
-        // simulation to enable an approver to see what the final state change
-        // will look like upon transaction execution. The multisig threshold
-        // will not actually change in the transaction execution.
-        overrides[0] = overrideSafeThresholdAndNonce(_safe, _nonce);
+        overrides[0] = _addOverrides(_safe, address(0), _nonce);
 
         logSimulationLink({
             _to: _safe,
@@ -154,5 +150,15 @@ abstract contract MultisigBuilder is MultisigBase {
             _from: msg.sender,
             _overrides: overrides
         });
+    }
+
+    // The state change simulation can set the threshold, owner address and/or nonce.
+    // This allows a non-signing owner to simulate the transaction
+    // State changes reflected in the simulation as a result of these overrides
+    // will not be reflected in the prod execution. 
+    // This particular implementation can be overwritten by an inheriting script. The 
+    // default logic is vestigial for backwards compatibility. 
+    function _addOverrides(address _safe, address, uint256 _nonce) internal virtual view returns (SimulationStateOverride memory) {
+        return overrideSafeThresholdAndNonce(_safe, _nonce);
     }
 }


### PR DESCRIPTION
The new hook `_addOverrides` in `MultisigBuilder` allows for arbitrary override capacity in an inheriting script. This is cleaner than overwriting the entirety of `_simulateForSigner` when most of the method is left unaffected. 

I've left `_simulateForSigner` as virtual in case the `_addOverrides` hook doesn't offer enough flexibility. 