### PR TITLE
feat: simulates transactions in forge and exposes state diff and sim info

### DIFF
--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -5,6 +5,7 @@ import "./MultisigBase.sol";
 
 import { console } from "forge-std/console.sol";
 import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
+import { Vm } from "forge-std/Vm.sol";
 
 /**
  * @title MultisigBuilder
@@ -20,7 +21,7 @@ abstract contract MultisigBuilder is MultisigBase {
     /**
      * @notice Follow up assertions to ensure that the script ran to completion.
      */
-    function _postCheck() internal virtual view;
+    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) internal virtual;
 
     /**
      * @notice Creates the calldata
@@ -48,12 +49,12 @@ abstract contract MultisigBuilder is MultisigBase {
      * Alternatively, this method can be called by a threshold of signers, and those signatures
      * used by a separate tx executor address in step 2, which doesn't have to be a signer.
      */
-    function sign() public view returns (bool) {
+    function sign() public {
         address safe = _ownerSafe();
         IMulticall3.Call3[] memory calls = _buildCalls();
-        _simulateForSigner(safe, calls);
+        (Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) = _simulateForSigner(safe, calls);
+        _postCheck(accesses, simPayload);
         _printDataToSign(safe, calls);
-        return true;
     }
 
     /**
@@ -77,14 +78,13 @@ abstract contract MultisigBuilder is MultisigBase {
      * Simulate the transaction. This method should be called by the final member of the multisig
      * that will execute the transaction. Signatures from step 1 are required.
      */
-    function simulateSigned(bytes memory _signatures) public returns (bool) {
+    function simulateSigned(bytes memory _signatures) public {
         address _safe = _ownerSafe();
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         uint256 _nonce = _getNonce(safe);
         vm.store(_safe, bytes32(uint256(5)), bytes32(uint256(_nonce)));
-        bool success = _executeTransaction(_safe, _buildCalls(), _signatures);
-        if (success) _postCheck();
-        return success;
+        (Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) = _executeTransaction(_safe, _buildCalls(), _signatures);
+        _postCheck(accesses, simPayload);
     }
 
     /**
@@ -96,14 +96,16 @@ abstract contract MultisigBuilder is MultisigBase {
      * Alternatively, this method can be called after a threshold of signatures is collected from
      * step 1. In this scenario, the caller doesn't need to be a signer of the multisig.
      */
-    function run(bytes memory _signatures) public returns (bool) {
+    function run(bytes memory _signatures) public {
         vm.startBroadcast();
-        bool success = _executeTransaction(_ownerSafe(), _buildCalls(), _signatures);
-        if (success) _postCheck();
-        return success;
+        (Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) = _executeTransaction(_ownerSafe(), _buildCalls(), _signatures);
+        _postCheck(accesses, simPayload);
     }
 
-    function _simulateForSigner(address _safe, IMulticall3.Call3[] memory _calls) internal virtual view {
+    function _simulateForSigner(address _safe, IMulticall3.Call3[] memory _calls)
+        internal
+        returns (Vm.AccountAccess[] memory, SimulationPayload memory)
+    {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (_calls));
 
@@ -111,41 +113,53 @@ abstract contract MultisigBuilder is MultisigBase {
         overrides[0] = _addOverrides(_safe);
         overrides[1] = _addGenericOverrides();
 
+        bytes memory txData = abi.encodeCall(safe.execTransaction,
+            (
+                address(multicall),
+                0,
+                data,
+                Enum.Operation.DelegateCall,
+                0,
+                0,
+                0,
+                address(0),
+                payable(address(0)),
+                prevalidatedSignature(msg.sender)
+            )
+        );
+
         logSimulationLink({
             _to: _safe,
-            _data: abi.encodeCall(
-                safe.execTransaction,
-                (
-                    address(multicall),
-                    0,
-                    data,
-                    Enum.Operation.DelegateCall,
-                    0,
-                    0,
-                    0,
-                    address(0),
-                    payable(address(0)),
-                    prevalidatedSignature(msg.sender)
-                )
-            ),
+            _data: txData,
             _from: msg.sender,
             _overrides: overrides
         });
+
+        // Forge simulation of the data logged in the link. If the simulation fails
+        // we revert to make it explicit that the simulation failed.
+        SimulationPayload memory simPayload = SimulationPayload({
+            from: msg.sender,
+            to: _safe,
+            data: txData,
+            stateOverrides: overrides
+        });
+        Vm.AccountAccess[] memory accesses = simulateFromSimPayload(simPayload);
+        return (accesses, simPayload);
     }
 
     // The state change simulation can set the threshold, owner address and/or nonce.
     // This allows a non-signing owner to simulate the transaction
     // State changes reflected in the simulation as a result of these overrides
-    // will not be reflected in the prod execution. 
-    // This particular implementation can be overwritten by an inheriting script. The 
-    // default logic is vestigial for backwards compatibility. 
+    // will not be reflected in the prod execution.
+    // This particular implementation can be overwritten by an inheriting script. The
+    // default logic is vestigial for backwards compatibility.
     function _addOverrides(address _safe) internal virtual view returns (SimulationStateOverride memory) {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         uint256 _nonce = _getNonce(safe);
         return overrideSafeThresholdAndNonce(_safe, _nonce);
     }
 
-    // Tenderly simulations can accept generic state overrides. This hook enables this functionality. 
-    // By default, an empty (no-op) override is returned 
+    // Tenderly simulations can accept generic state overrides. This hook enables this functionality.
+    // By default, an empty (no-op) override is returned
     function _addGenericOverrides() internal virtual view returns (SimulationStateOverride memory override_) {}
 }

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -99,6 +99,8 @@ abstract contract MultisigBuilder is MultisigBase {
     function run(bytes memory _signatures) public {
         vm.startBroadcast();
         (Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) = _executeTransaction(_ownerSafe(), _buildCalls(), _signatures);
+        vm.stopBroadcast();
+
         _postCheck(accesses, simPayload);
     }
 

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -138,9 +138,9 @@ abstract contract MultisigBuilder is MultisigBase {
         // Forge simulation of the data logged in the link. If the simulation fails
         // we revert to make it explicit that the simulation failed.
         SimulationPayload memory simPayload = SimulationPayload({
-            from: msg.sender,
             to: _safe,
             data: txData,
+            from: msg.sender,
             stateOverrides: overrides
         });
         Vm.AccountAccess[] memory accesses = simulateFromSimPayload(simPayload);

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -226,9 +226,9 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         // Forge simulation of the data logged in the link. If the simulation fails
         // we revert to make it explicit that the simulation failed.
         SimulationPayload memory simPayload = SimulationPayload({
-            from: msg.sender,
-            to: _safe,
+            to: address(multicall),
             data: txData,
+            from: msg.sender,
             stateOverrides: overrides
         });
         Vm.AccountAccess[] memory accesses = simulateFromSimPayload(simPayload);

--- a/script/universal/Simulator.sol
+++ b/script/universal/Simulator.sol
@@ -43,7 +43,7 @@ abstract contract Simulator is CommonBase {
         vm.prank(simPayload.from);
         (bool ok, bytes memory returnData) = address(simPayload.to).call(simPayload.data);
         Vm.AccountAccess[] memory accesses = vm.stopAndReturnStateDiff();
-        require(ok, string.concat("Simulator::simulateFromSimPayload failed", vm.toString(returnData)));
+        require(ok, string.concat("Simulator::simulateFromSimPayload failed: ", vm.toString(returnData)));
         require(accesses.length > 0, "Simulator::simulateFromSimPayload: No state changes");
         return accesses;
     }


### PR DESCRIPTION
To facilitate the following features:
1. State diff assertions using state diffs from foundry.
2. Exposing transaction simulation payloads for simulating with external tools such as Tenderly.
3. Failing when a simulation or execution reverts or does not result in any state changes.

The below changes were made:
1. The postCheck hook takes state diff and simulation payload inputs.
2. The postCheck hook is mutable to enable ffi calls to further validate the transaction results.
3. Anytime a transaction is executed, whether simulated or broadcast, the state diff is recorded and returned to the caller.
4. The postCheck hook is always run after a transaction, whether simulated or broadcast.
5. Booleans returned from methods have been removed, as the methods will now revert if a transaction fails so they are no longer needed.

We had to copy out logic from the base repo in order to execute a simulation in foundry and make assertions on the state diff, as you can see here: https://github.com/ethereum-optimism/superchain-ops/pull/119/commits/815a5c42b99497a0de537aa28a7a658198926ba7

~~I'd still need to test this branch and make sure no changes were missed, and that it works properly to let us simplify that linked commit, but I wanted to open this draft PR to get feedback on the architecture from a high level and see if you'd be open to merging this PR.~~ — Edit: I've now tested this in the upstream https://github.com/ethereum-optimism/superchain-ops/pull/130 and it seems to be working!
