### PR TITLE
Remove the `delayedVetoable` param from the `Vetoer1of2` constructor 

### DIFF
--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -2,73 +2,80 @@
 pragma solidity 0.8.15;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {DelayedVetoable} from "@eth-optimism-bedrock/src/L1/DelayedVetoable.sol";
 
-/**
- * @title Vetoer1of2
- * @dev This contract serves the role of the Vetoer, defined in DelayedVetoable.sol:
- * https://github.com/ethereum-optimism/optimism/blob/d72fb46daf3a6831cb01a78931f8c6e0d52ae243/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
- * It enforces a simple 1 of 2 design, where neither party can remove the other's
- * permissions to execute a Veto call.
- */
+/// @title Vetoer1of2
+///
+/// @dev This contract serves the role of the Vetoer, defined in DelayedVetoable.sol:
+///      https://github.com/ethereum-optimism/optimism/blob/d72fb46daf3a6831cb01a78931f8c6e0d52ae243/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
+///      It enforces a simple 1 of 2 design, where neither party can remove the other's
+///      permissions to execute a Veto call.
+///
 contract Vetoer1of2 {
     using Address for address;
 
-    /*//////////////////////////////////////////////////////////////
-                            CONSTANTS
-    //////////////////////////////////////////////////////////////*/
-    /**
-     * @dev The address of Optimism's signer (likely a multisig)
-     */
+    /////////////////////////////////////////////////////////////
+    //                        CONSTANTS                        //
+    /////////////////////////////////////////////////////////////
+
+    /// @notice The address of Optimism's signer (likely a multisig)
     address public immutable opSigner;
 
-    /**
-     * @dev The address of counter party's signer (likely a multisig)
-     */
+    /// @notice The address of counter party's signer (likely a multisig)
     address public immutable otherSigner;
 
-    /**
-     * @dev The address of the L2OutputOracleProxy contract.
-     */
+    /// @notice The address of the L2OutputOracleProxy contract.
     address public immutable delayedVetoable;
 
-    /*//////////////////////////////////////////////////////////////
-                            EVENTS
-    //////////////////////////////////////////////////////////////*/
-    /**
-     * @dev Emitted when a Veto call is made by a signer.
-     * @param caller The signer making the call.
-     * @param data The data of the call being made.
-     * @param result The result of the call being made.
-     */
+    //////////////////////////////////////////////////////////////
+    //                        EVENTS                            //
+    //////////////////////////////////////////////////////////////
+
+    /// @notice Emitted when a Veto call is made by a signer.
+    ///
+    /// @param caller The signer making the call.
+    /// @param data The data of the call being made.
+    /// @param result The result of the call being made.
     event VetoCallExecuted(address indexed caller, bytes data, bytes result);
 
-    /*//////////////////////////////////////////////////////////////
-                            Constructor
-    //////////////////////////////////////////////////////////////*/
-    /**
-     * @dev Constructor to set the values of the constants.
-     * @param opSigner_ Address of Optimism signer.
-     * @param otherSigner_ Address of counter party signer.
-     * @param delayedVetoable_ Address of the DelayedVetoable contract.
-     */
-    constructor(address opSigner_, address otherSigner_, address delayedVetoable_) {
+    //////////////////////////////////////////////////////////////
+    //                        Constructor                       //
+    //////////////////////////////////////////////////////////////
+
+    /// @notice Constructor to set the values of the constants.
+    ///
+    /// @dev The `DelayedVetoable` contract is deployed in this constructor to easily establish
+    ///      the link between both contracts.
+    ///
+    /// @param opSigner_ Address of Optimism signer.
+    /// @param otherSigner_ Address of counter party signer.
+    /// @param initiator Address of the initiator.
+    /// @param target Address of the target.
+    /// @param operatingDelay Time to delay when the system is operational.
+    constructor(address opSigner_, address otherSigner_, address initiator, address target, uint256 operatingDelay) {
         require(opSigner_ != address(0), "Vetoer1of2: opSigner cannot be zero address");
         require(otherSigner_ != address(0), "Vetoer1of2: otherSigner cannot be zero address");
-        require(delayedVetoable_.isContract(), "Vetoer1of2: delayedVetoable must be a contract");
 
         opSigner = opSigner_;
         otherSigner = otherSigner_;
-        delayedVetoable = delayedVetoable_;
+
+        delayedVetoable = address(
+            new DelayedVetoable({
+                vetoer_: address(this),
+                initiator_: initiator,
+                target_: target,
+                operatingDelay_: operatingDelay
+            })
+        );
     }
 
-    /*//////////////////////////////////////////////////////////////
-                        External Functions
-    //////////////////////////////////////////////////////////////*/
-    /**
-     * @dev Executes a call as the Vetoer (must be called by
-     * Optimism or counter party signer).
-     * @param data Data for function call.
-     */
+    //////////////////////////////////////////////////////////////
+    //                    External Functions                    //
+    //////////////////////////////////////////////////////////////
+
+    /// @notice Executes a call as the Vetoer (must be called by Optimism or counter party signer).
+    ///
+    /// @param data Data for function call.
     function execute(bytes memory data) external {
         require(
             msg.sender == otherSigner || msg.sender == opSigner, "Vetoer1of2: must be an approved signer to execute"

--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -26,6 +26,11 @@ contract Vetoer1of2 {
      */
     address public immutable otherSigner;
 
+    /**
+     * @dev The address of the L2OutputOracleProxy contract.
+     */
+    address public immutable delayedVetoable;
+
     /*//////////////////////////////////////////////////////////////
                             EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -44,13 +49,16 @@ contract Vetoer1of2 {
      * @dev Constructor to set the values of the constants.
      * @param opSigner_ Address of Optimism signer.
      * @param otherSigner_ Address of counter party signer.
+     * @param delayedVetoable_ Address of the DelayedVetoable contract.
      */
-    constructor(address opSigner_, address otherSigner_) {
+    constructor(address opSigner_, address otherSigner_, address delayedVetoable_) {
         require(opSigner_ != address(0), "Vetoer1of2: opSigner cannot be zero address");
         require(otherSigner_ != address(0), "Vetoer1of2: otherSigner cannot be zero address");
+        require(delayedVetoable_.isContract(), "Vetoer1of2: delayedVetoable must be a contract");
 
         opSigner = opSigner_;
         otherSigner = otherSigner_;
+        delayedVetoable = delayedVetoable_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -60,9 +68,8 @@ contract Vetoer1of2 {
      * @dev Executes a call as the Vetoer (must be called by
      * Optimism or counter party signer).
      * @param data Data for function call.
-     * @param delayedVetoable Address of the DelayedVetoable contract to call.
      */
-    function execute(bytes memory data, address delayedVetoable) external {
+    function execute(bytes memory data) external {
         require(
             msg.sender == otherSigner || msg.sender == opSigner, "Vetoer1of2: must be an approved signer to execute"
         );

--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -26,11 +26,6 @@ contract Vetoer1of2 {
      */
     address public immutable otherSigner;
 
-    /**
-     * @dev The address of the L2OutputOracleProxy contract.
-     */
-    address public immutable delayedVetoable;
-
     /*//////////////////////////////////////////////////////////////
                             EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -49,16 +44,13 @@ contract Vetoer1of2 {
      * @dev Constructor to set the values of the constants.
      * @param opSigner_ Address of Optimism signer.
      * @param otherSigner_ Address of counter party signer.
-     * @param delayedVetoable_ Address of the DelayedVetoable contract.
      */
-    constructor(address opSigner_, address otherSigner_, address delayedVetoable_) {
+    constructor(address opSigner_, address otherSigner_) {
         require(opSigner_ != address(0), "Vetoer1of2: opSigner cannot be zero address");
         require(otherSigner_ != address(0), "Vetoer1of2: otherSigner cannot be zero address");
-        require(delayedVetoable_.isContract(), "Vetoer1of2: delayedVetoable must be a contract");
 
         opSigner = opSigner_;
         otherSigner = otherSigner_;
-        delayedVetoable = delayedVetoable_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -68,8 +60,9 @@ contract Vetoer1of2 {
      * @dev Executes a call as the Vetoer (must be called by
      * Optimism or counter party signer).
      * @param data Data for function call.
+     * @param delayedVetoable Address of the DelayedVetoable contract to call.
      */
-    function execute(bytes memory data) external {
+    function execute(bytes memory data, address delayedVetoable) external {
         require(
             msg.sender == otherSigner || msg.sender == opSigner, "Vetoer1of2: must be an approved signer to execute"
         );

--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -24,7 +24,7 @@ contract Vetoer1of2 {
     /// @notice The address of counter party's signer (likely a multisig)
     address public immutable otherSigner;
 
-    /// @notice The address of the L2OutputOracleProxy contract.
+    /// @notice The address of the DelayedVetoable contract.
     address public immutable delayedVetoable;
 
     //////////////////////////////////////////////////////////////

--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -34,9 +34,8 @@ contract Vetoer1of2 {
     /// @notice Emitted when a Veto call is made by a signer.
     ///
     /// @param caller The signer making the call.
-    /// @param data The data of the call being made.
     /// @param result The result of the call being made.
-    event VetoCallExecuted(address indexed caller, bytes data, bytes result);
+    event VetoCallExecuted(address indexed caller, bytes result);
 
     //////////////////////////////////////////////////////////////
     //                        Constructor                       //
@@ -73,16 +72,20 @@ contract Vetoer1of2 {
     //                    External Functions                    //
     //////////////////////////////////////////////////////////////
 
-    /// @notice Executes a call as the Vetoer (must be called by Optimism or counter party signer).
+    /// @notice Passthrough for either signer to execute a veto on the `DelayedVetoable` contract.
     ///
-    /// @param data Data for function call.
-    function execute(bytes memory data) external {
+    /// @dev Revert if not called by `opSigner` or `otherSigner`.
+    function veto() external {
         require(
             msg.sender == otherSigner || msg.sender == opSigner, "Vetoer1of2: must be an approved signer to execute"
         );
 
-        bytes memory result = Address.functionCall(delayedVetoable, data, "Vetoer1of2: failed to execute");
+        bytes memory result = Address.functionCall({
+            target: delayedVetoable,
+            data: msg.data,
+            errorMessage: "Vetoer1of2: failed to execute"
+        });
 
-        emit VetoCallExecuted(msg.sender, data, result);
+        emit VetoCallExecuted({caller: msg.sender, result: result});
     }
 }

--- a/src/Vetoer1of2.sol
+++ b/src/Vetoer1of2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title Vetoer1of2
@@ -19,53 +19,46 @@ contract Vetoer1of2 {
     /**
      * @dev The address of Optimism's signer (likely a multisig)
      */
-    address public immutable OP_SIGNER;
+    address public immutable opSigner;
 
     /**
      * @dev The address of counter party's signer (likely a multisig)
      */
-    address public immutable OTHER_SIGNER;
+    address public immutable otherSigner;
 
     /**
      * @dev The address of the L2OutputOracleProxy contract.
      */
-    address public immutable DELAYED_VETOABLE;
+    address public immutable delayedVetoable;
 
     /*//////////////////////////////////////////////////////////////
                             EVENTS
     //////////////////////////////////////////////////////////////*/
     /**
      * @dev Emitted when a Veto call is made by a signer.
-     * @param _caller The signer making the call.
-     * @param _data The data of the call being made.
-     * @param _result The result of the call being made.
+     * @param caller The signer making the call.
+     * @param data The data of the call being made.
+     * @param result The result of the call being made.
      */
-    event VetoCallExecuted(
-        address indexed _caller,
-        bytes _data,
-        bytes _result
-    );
+    event VetoCallExecuted(address indexed caller, bytes data, bytes result);
 
     /*//////////////////////////////////////////////////////////////
                             Constructor
     //////////////////////////////////////////////////////////////*/
     /**
      * @dev Constructor to set the values of the constants.
-     * @param _opSigner Address of Optimism signer.
-     * @param _otherSigner Address of counter party signer.
-     * @param _delayedVetoable Address of the DelayedVetoable contract.
+     * @param opSigner_ Address of Optimism signer.
+     * @param otherSigner_ Address of counter party signer.
+     * @param delayedVetoable_ Address of the DelayedVetoable contract.
      */
-    constructor(address _opSigner, address _otherSigner, address _delayedVetoable) {
-        require(_opSigner != address(0), "Vetoer1of2: opSigner cannot be zero address");
-        require(_otherSigner != address(0), "Vetoer1of2: otherSigner cannot be zero address");
-        require(
-            _delayedVetoable.isContract(),
-            "Vetoer1of2: delayedVetoable must be a contract"
-        );
+    constructor(address opSigner_, address otherSigner_, address delayedVetoable_) {
+        require(opSigner_ != address(0), "Vetoer1of2: opSigner cannot be zero address");
+        require(otherSigner_ != address(0), "Vetoer1of2: otherSigner cannot be zero address");
+        require(delayedVetoable_.isContract(), "Vetoer1of2: delayedVetoable must be a contract");
 
-        OP_SIGNER = _opSigner;
-        OTHER_SIGNER = _otherSigner;
-        DELAYED_VETOABLE = _delayedVetoable;
+        opSigner = opSigner_;
+        otherSigner = otherSigner_;
+        delayedVetoable = delayedVetoable_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -74,20 +67,15 @@ contract Vetoer1of2 {
     /**
      * @dev Executes a call as the Vetoer (must be called by
      * Optimism or counter party signer).
-     * @param _data Data for function call.
+     * @param data Data for function call.
      */
-    function execute(bytes memory _data) external {
+    function execute(bytes memory data) external {
         require(
-            msg.sender == OTHER_SIGNER || msg.sender == OP_SIGNER,
-            "Vetoer1of2: must be an approved signer to execute"
+            msg.sender == otherSigner || msg.sender == opSigner, "Vetoer1of2: must be an approved signer to execute"
         );
 
-        bytes memory result = Address.functionCall(
-            DELAYED_VETOABLE,
-            _data,
-            "Vetoer1of2: failed to execute"
-        );
+        bytes memory result = Address.functionCall(delayedVetoable, data, "Vetoer1of2: failed to execute");
 
-        emit VetoCallExecuted(msg.sender, _data, result);
+        emit VetoCallExecuted(msg.sender, data, result);
     }
 }


### PR DESCRIPTION
This PR simplifies the deployment of the `Vetoer1of2` along with its associated `DelayedVetoable` contract by removing the circular dependency between both of them.

The `DELAYED_VETOABLE` immutable set at deployment in the `Vetoer1of2` is replaced by the additional `delayedVetoable`parameter that must be provided when calling the `execute` method.

Additionally, variables have been renamed to match with our [style guide](https://github.com/coinbase/solidity-style-guide).