### PR TITLE
fix: snapshot and restore Safe nonce

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -9,6 +9,7 @@ import "./Simulator.sol";
 
 abstract contract MultisigBase is Simulator {
     IMulticall3 internal constant multicall = IMulticall3(MULTICALL3_ADDRESS);
+    bytes32 internal constant SAFE_NONCE_SLOT = bytes32(uint256(5));
 
     function _getTransactionHash(address _safe, IMulticall3.Call3[] memory calls) internal view returns (bytes32) {
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (calls));

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -53,7 +53,7 @@ abstract contract MultisigBuilder is MultisigBase {
         address safe = _ownerSafe();
 
         // Snapshot and restore Safe nonce after simulation, otherwise the data logged to sign
-        // would be not matching the actual data we need to sign, because the simulation
+        // would not match the actual data we need to sign, because the simulation
         // would increment the nonce.
         uint256 originalNonce = IGnosisSafe(safe).nonce();
 

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -52,7 +52,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         address nestedSafeAddress = _ownerSafe();
 
         // Snapshot and restore Safe nonce after simulation, otherwise the data logged to sign
-        // would be not matching the actual data we need to sign, because the simulation
+        // would not match the actual data we need to sign, because the simulation
         // would increment the nonce.
         uint256 originalNonce = IGnosisSafe(nestedSafeAddress).nonce();
 

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -50,6 +50,12 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      */
     function sign(address _signerSafe) public {
         address nestedSafeAddress = _ownerSafe();
+
+        // Snapshot and restore Safe nonce after simulation, otherwise the data logged to sign
+        // would be not matching the actual data we need to sign, because the simulation
+        // would increment the nonce.
+        uint256 originalNonce = IGnosisSafe(nestedSafeAddress).nonce();
+
         IMulticall3.Call3[] memory nestedCalls = _buildCalls();
         IMulticall3.Call3 memory call = _generateApproveCall(nestedSafeAddress, nestedCalls);
         bytes32 hash = _getTransactionHash(_signerSafe, toArray(call));
@@ -58,6 +64,10 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         console.logBytes32(hash);
         (Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) = _simulateForSigner(_signerSafe, nestedSafeAddress, nestedCalls);
         _postCheck(accesses, simPayload);
+
+        // Restore the original nonce.
+        vm.store(nestedSafeAddress, SAFE_NONCE_SLOT, bytes32(uint256(originalNonce)));
+
         _printDataToSign(_signerSafe, toArray(call));
     }
 


### PR DESCRIPTION
We recently merged https://github.com/base-org/contracts/pull/72. Prior to this PR, foundry did not simulate the transaction, and just logged the data needed to generate the tenderly sim. As a result, when forge called `safe.nonce()` at the very end of the solidity script, it matched what was on the actual chain.

In that PR, we modified the scripts so forge always applies the required state overrides and simulates the transaction. This was done so we can use the state diff recording cheats in foundry and make assertions on the diff.
However, the actual logging of the `Data to sign:` that's in the terminal calls `safe.nonce()` _after_ the foundry simulation, so it's one too high.

This PR snapshots the safe nonce prior to simulation and restores it after, so the data to sign is corrected logged.