### PR TITLE
Addition of important log message for signers

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -67,7 +67,12 @@ abstract contract MultisigBase is Simulator {
         console.log("---\nData to sign:");
         console.log("vvvvvvvv");
         console.logBytes(txData);
-        console.log("^^^^^^^^");
+        console.log("^^^^^^^^\n");
+
+        console.log("########## IMPORTANT ##########");
+        console.log("Please make sure that the 'Data to sign' displayed above matches what you see in the simulation and on your hardware wallet.");
+        console.log("This is a critical step that must not be skipped.");
+        console.log("###############################");
     }
 
     function _checkSignatures(address _safe, IMulticall3.Call3[] memory _calls, bytes memory _signatures)


### PR DESCRIPTION
Checking the terminals domain + message hash matches what's displayed on a signers hardware wallet and simulation is an imperative step in the process. 

The run book does instruct signers to do this but reinforcement of this message is very important.

This PR changes the output slightly. Below is a screenshot of this change in action:
 
<img width="1386" alt="Screenshot 2024-05-10 at 11 02 57" src="https://github.com/base-org/contracts/assets/15608778/e896f561-8f29-4122-933e-6b3c7d5dc66a">
