### PR TITLE
SmartEscrow Audit Feedback 

### DIFF
--- a/src/smart-escrow/SmartEscrow.sol
+++ b/src/smart-escrow/SmartEscrow.sol
@@ -183,7 +183,6 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
     /// @notice Releases any vested token to the beneficiary before terminating.
     /// @notice Emits a {ContractTerminated} event.
     function terminate() external onlyRole(TERMINATOR_ROLE) {
-        if (contractTerminated) revert ContractIsTerminated();
         release();
         contractTerminated = true;
         emit ContractTerminated();

--- a/src/smart-escrow/SmartEscrow.sol
+++ b/src/smart-escrow/SmartEscrow.sol
@@ -198,6 +198,8 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
     }
 
     /// @notice Allow benefactor owner to update benefactor address.
+    /// @dev This method does not adjust the BENEFACTOR_OWNER_ROLE. Ensure to pair calling this
+    /// with a role change by DEFAULT_ADMIN if this is the desired outcome.  
     /// @param _newBenefactor New benefactor address.
     /// @notice Emits a {BenefactorUpdated} event.
     function updateBenefactor(address _newBenefactor) external onlyRole(BENEFACTOR_OWNER_ROLE) {
@@ -210,6 +212,8 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
     }
 
     /// @notice Allow beneficiary owner to update beneficiary address.
+    /// @dev This method does not adjust the BENEFICIARY_OWNER_ROLE. Ensure to pair calling this
+    /// with a role change by DEFAULT_ADMIN if this is the desired outcome.
     /// @param _newBeneficiary New beneficiary address.
     /// @notice Emits a {BeneficiaryUpdated} event.
     function updateBeneficiary(address _newBeneficiary) external onlyRole(BENEFICIARY_OWNER_ROLE) {


### PR DESCRIPTION
This PR incorporates feedback from the second smart contract escrow audit conducted by spearbit:

1.  will do
2.  I think that the clearer error messaging on construction is more helpful than the minimal gas removing the check saves. Won't do
3. Same reasoning as 2). Won't do
4. See PR comments below for context; ultimately; No change needed. 

--- FROM SPEARBIT --- 
1. Redundant contractTerminated check, will be checked in release()
https://github.com/base-org/contracts/blob/b49add823005826521b5b8d8cf8a7a292420f0bd/src/smart-escrow/SmartEscrow.sol#L186

3. https://github.com/base-org/contracts/blob/b49add823005826521b5b8d8cf8a7a292420f0bd/src/smart-escrow/SmartEscrow.sol#L155-L157
if (_start >= _end) revert StartTimeAfterEndTime(_start, _end);
Technically redundant as it will be covered by the checks:
if (_cliffStart < _start) and if (_cliffStart >= _end)
which enforces _start <= _cliffStart < end

5. https://github.com/base-org/contracts/blob/b49add823005826521b5b8d8cf8a7a292420f0bd/src/smart-escrow/SmartEscrow.sol#L160-L165
Likewise, the check below is technically redundant
if ((_end - _start) < _vestingPeriodSeconds) {
  revert VestingPeriodExceedsContractDuration(_vestingPeriodSeconds);
}
because it will be covered by this check:
if ((_end - _start) % _vestingPeriodSeconds != 0)

6. Wanna confirm the expected behaviour for access control and benefactor / beneficiary address changes.
The updateBenefactor() / updateBeneficiary() can only be called by BENEFACTOR_OWNER_ROLE / BENEFICIARY_OWNER_ROLE respectively, but this strictly updates the benefactor / beneficiary variables. Access control updates: revoking the OWNER and TERMINATOR roles of the old address, and granting them to the new one, is handled by the public grantRole() / revokeRole() / renounceRole() methods. (edited) 