### PR TITLE
Allow adding multiple contract overrides

### DIFF
--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -121,7 +121,6 @@ abstract contract MultisigBuilder is MultisigBase {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (_calls));
 
-        // Initialize the overrides array with a length based on the number of generic overrides returned above.
         SimulationStateOverride[] memory overrides = _setOverrides(_safe);
 
         bytes memory txData = abi.encodeCall(safe.execTransaction,


### PR DESCRIPTION
Adds a new virtual function `_addMultipleGenericOverrides` which can be used to set overrides for multiple contracts.

The new function can be used alongside or instead of `_addGenericOverrides` thus maintaining backwards compatibility with pre-existing scripts. 

This PR also slightly improves the UX of reviewing a simulation, as empty overrides will no longer be included in the Tenderly URL. Previously these empty overrides also appeared in  the list of State Overrides on Tenderly.

