### PR TITLE
Allow reinitialization of the BalanceTracker

### DIFF
--- a/src/revenue-share/BalanceTracker.sol
+++ b/src/revenue-share/BalanceTracker.sol
@@ -107,7 +107,7 @@ contract BalanceTracker is ReentrancyGuardUpgradeable {
     function initialize(
         address payable[] memory _systemAddresses,
         uint256[] memory _targetBalances
-    ) external initializer {
+    ) external reinitializer(2) {
         uint256 systemAddresesLength = _systemAddresses.length;
         require(systemAddresesLength > 0, 
             "BalanceTracker: systemAddresses cannot have a length of zero");


### PR DESCRIPTION
We want to redeploy this with different target balances. This will allow us to reinitialize the targets + balances stored in the proxy.