### PR TITLE
Remove start time check on SmartEscrow

### DIFF
--- a/src/smart-escrow/SmartEscrow.sol
+++ b/src/smart-escrow/SmartEscrow.sol
@@ -81,11 +81,6 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
     /// @notice The error is thrown when an address is not set.
     error AddressIsZeroAddress();
 
-    /// @notice The error is thrown when the start timestamp is in the past.
-    /// @param startTimestamp The provided start time of the contract.
-    /// @param currentTime The current time.
-    error StartTimeCannotBeInPast(uint256 startTimestamp, uint256 currentTime);
-
     /// @notice The error is thrown when the start timestamp is greater than the end timestamp.
     /// @param startTimestamp The provided start time of the contract.
     /// @param endTimestamp The provided end time of the contract.
@@ -151,7 +146,6 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
         _beneficiaryOwner == address(0) || _benefactorOwner == address(0)) {
             revert AddressIsZeroAddress();
         }
-        if (_start < block.timestamp) revert StartTimeCannotBeInPast(_start, block.timestamp);
         if (_start >= _end) revert StartTimeAfterEndTime(_start, _end);
         if (_cliffStart < _start) revert CliffStartTimeInvalid(_cliffStart, _start);
         if (_cliffStart >= _end) revert CliffStartTimeAfterEndTime(_cliffStart, _end);

--- a/test/smart-escrow/Constructor.t.sol
+++ b/test/smart-escrow/Constructor.t.sol
@@ -93,25 +93,6 @@ contract ConstructorSmartEscrow is BaseSmartEscrowTest {
         );
     }
 
-    function test_constructor_startTimeZero_fails() public {
-        vm.warp(100);
-        bytes4 pastStartTimeSelector = bytes4(keccak256("StartTimeCannotBeInPast(uint256,uint256)"));
-        vm.expectRevert(abi.encodeWithSelector(pastStartTimeSelector, 0, 100));
-        new SmartEscrow(
-            benefactor,
-            beneficiary,
-            benefactorOwner,
-            beneficiaryOwner,
-            escrowOwner,
-            0,
-            cliffStart,
-            end,
-            vestingPeriod,
-            initialTokens,
-            vestingEventTokens
-        );
-    }
-
     function test_constructor_cliffStartTimeZero_fails() public {
         vm.warp(100);
         bytes4 pastStartTimeSelector = bytes4(keccak256("CliffStartTimeInvalid(uint256,uint256)"));


### PR DESCRIPTION
we had a check that the start time of the contract was not in the past, but this is now the case, so removing this check