### PR TITLE
feat: Add Upgrade and Rollback GasLimit scripts

### DIFF
--- a/script/deploy/l1/RollbackGasLimit.sol
+++ b/script/deploy/l1/RollbackGasLimit.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import './SetGasLimitBuilder.sol';
+
+contract RollbackGasLimit is SetGasLimitBuilder {
+    function _fromGasLimit() internal view override returns (uint64) {
+        return uint64(vm.envUint("NEW_GAS_LIMIT"));
+    }
+
+    function _toGasLimit() internal view override returns (uint64) {
+        return uint64(vm.envUint("OLD_GAS_LIMIT"));
+    }
+
+    function _nonceOffset() internal pure override returns (uint64) {
+        return 1;
+    }
+}

--- a/script/deploy/l1/UpgradeGasLimit.sol
+++ b/script/deploy/l1/UpgradeGasLimit.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import './SetGasLimitBuilder.sol';
+
+contract UpgradeGasLimit is SetGasLimitBuilder {
+    function _fromGasLimit() internal view override returns (uint64) {
+        return uint64(vm.envUint("OLD_GAS_LIMIT"));
+    }
+
+    function _toGasLimit() internal view override returns (uint64) {
+        return uint64(vm.envUint("NEW_GAS_LIMIT"));
+    }
+
+    function _nonceOffset() internal pure override returns (uint64) {
+        return 0;
+    }
+}


### PR DESCRIPTION
Builds upon #91, adding standard `UpgradeGasLimit` and `RollbackGasLimit` scripts. This allows us to perform repeatable gas limit upgrades with pre-signed rollbacks without adding any new solidity to base-org/contract-deployments