### PR TITLE
feat: Allow env nonce overrides for gas limit changes

### DIFF
--- a/script/deploy/l1/RollbackGasLimit.sol
+++ b/script/deploy/l1/RollbackGasLimit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import './SetGasLimitBuilder.sol';
+import "./SetGasLimitBuilder.sol";
 
 contract RollbackGasLimit is SetGasLimitBuilder {
     function _fromGasLimit() internal view override returns (uint64) {
@@ -12,7 +12,11 @@ contract RollbackGasLimit is SetGasLimitBuilder {
         return uint64(vm.envUint("OLD_GAS_LIMIT"));
     }
 
-    function _nonceOffset() internal pure override returns (uint64) {
-        return 1;
+    function _nonceOffset() internal view override returns (uint64) {
+        try vm.envUint("ROLLBACK_NONCE_OFFSET") {
+            return uint64(vm.envUint("ROLLBACK_NONCE_OFFSET"));
+        } catch {
+            return 1;
+        }
     }
 }

--- a/script/deploy/l1/SetGasLimitBuilder.sol
+++ b/script/deploy/l1/SetGasLimitBuilder.sol
@@ -51,9 +51,13 @@ abstract contract SetGasLimitBuilder is MultisigBuilder {
         return SYSTEM_CONFIG_OWNER;
     }
 
+    function _getNonce(IGnosisSafe safe) internal view override returns (uint256 nonce) {
+        nonce = safe.nonce() + _nonceOffset();
+    }
+
     function _addOverrides(address _safe) internal view override returns (SimulationStateOverride memory) {
         IGnosisSafe safe = IGnosisSafe(payable(_safe));
-        uint256 _nonce = _getNonce(safe) + _nonceOffset();
+        uint256 _nonce = _getNonce(safe);
         return overrideSafeThresholdOwnerAndNonce(_safe, DEFAULT_SENDER, _nonce);
     }
 

--- a/script/deploy/l1/UpgradeGasLimit.sol
+++ b/script/deploy/l1/UpgradeGasLimit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import './SetGasLimitBuilder.sol';
+import "./SetGasLimitBuilder.sol";
 
 contract UpgradeGasLimit is SetGasLimitBuilder {
     function _fromGasLimit() internal view override returns (uint64) {
@@ -12,7 +12,11 @@ contract UpgradeGasLimit is SetGasLimitBuilder {
         return uint64(vm.envUint("NEW_GAS_LIMIT"));
     }
 
-    function _nonceOffset() internal pure override returns (uint64) {
-        return 0;
+    function _nonceOffset() internal view override returns (uint64) {
+        try vm.envUint("UPGRADE_NONCE_OFFSET") {
+            return uint64(vm.envUint("UPGRADE_NONCE_OFFSET"));
+        } catch {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Allows the `UPGRADE_NONCE_OFFSET` and `ROLLBACK_NONCE_OFFSET` env vars to override the nonce offsets for gas limit upgrades and rollbacks respectively, allowing users to more easily pre-sign multiple upgrades and/or rollbacks.