### PR TITLE
Pass state accesses / simPayload to _postCheck

### DIFF
--- a/script/deploy/l1/SetGasLimitBuilder.sol
+++ b/script/deploy/l1/SetGasLimitBuilder.sol
@@ -25,7 +25,7 @@ abstract contract SetGasLimitBuilder is MultisigBuilder {
      * Implemented Functions
      * -----------------------------------------------------------
      */
-    function _postCheck() internal view override {
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
         assert(SystemConfig(L1_SYSTEM_CONFIG).gasLimit() == _toGasLimit());
     }
 

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -31,7 +31,7 @@ abstract contract MultisigBuilder is MultisigBase {
     /**
      * @notice Follow up assertions to ensure that the script ran to completion.
      */
-    function _postCheck() internal virtual;
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual;
 
     /**
      * @notice Follow up assertions on state and simulation after a `sign` call.
@@ -70,7 +70,7 @@ abstract contract MultisigBuilder is MultisigBase {
         IMulticall3.Call3[] memory calls = _buildCalls();
         (Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) = _simulateForSigner(safe, calls);
         _postSign(accesses, simPayload);
-        _postCheck();
+        _postCheck(accesses, simPayload);
 
         // Restore the original nonce.
         vm.store(address(safe), SAFE_NONCE_SLOT, bytes32(_nonce));
@@ -104,7 +104,7 @@ abstract contract MultisigBuilder is MultisigBase {
             _executeTransaction(safe, _buildCalls(), _signatures);
 
         _postRun(accesses, simPayload);
-        _postCheck();
+        _postCheck(accesses, simPayload);
     }
 
     /**
@@ -123,7 +123,7 @@ abstract contract MultisigBuilder is MultisigBase {
         vm.stopBroadcast();
 
         _postRun(accesses, simPayload);
-        _postCheck();
+        _postCheck(accesses, simPayload);
     }
 
     /**

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -31,7 +31,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      * @notice Follow up assertions to ensure that the script ran to completion.
      * @dev Called after `sign` and `run`, but not `approve`.
      */
-    function _postCheck() internal virtual;
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual;
 
     /**
      * @notice Follow up assertions on state and simulation after a `sign` call.
@@ -77,7 +77,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         (Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) =
             _simulateForSigner(_signerSafe, nestedSafe, nestedCalls);
         _postSign(accesses, simPayload);
-        _postCheck();
+        _postCheck(accesses, simPayload);
 
         // Restore the original nonce.
         vm.store(address(nestedSafe), SAFE_NONCE_SLOT, bytes32(originalNonce));
@@ -138,7 +138,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         vm.stopBroadcast();
 
         _postRun(accesses, simPayload);
-        _postCheck();
+        _postCheck(accesses, simPayload);
     }
 
     function _readFrom_SAFE_NONCE() internal pure override returns (bool) {

--- a/test/universal/MultisigBuilder.t.sol
+++ b/test/universal/MultisigBuilder.t.sol
@@ -7,6 +7,7 @@ import {console} from "forge-std/console.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {Preinstalls} from "@eth-optimism-bedrock/src/libraries/Preinstalls.sol";
 import {MultisigBuilder} from "../../script/universal/MultisigBuilder.sol";
+import {Simulation} from "../../script/universal/Simulation.sol";
 import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
 import {Counter} from "./Counter.sol";
 
@@ -30,7 +31,7 @@ contract MultisigBuilderTest is Test, MultisigBuilder {
         safe.setup(owners, 2, address(0), "", address(0), address(0), 0, address(0));
     }
 
-    function _postCheck() internal view override {
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
         // Check that the counter has been incremented
         uint256 counterValue = counter.count();
         require(counterValue == 1, "Counter value is not 1");

--- a/test/universal/NestedMultisigBuilder.t.sol
+++ b/test/universal/NestedMultisigBuilder.t.sol
@@ -7,6 +7,7 @@ import {console} from "forge-std/console.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {Preinstalls} from "@eth-optimism-bedrock/src/libraries/Preinstalls.sol";
 import {NestedMultisigBuilder} from "../../script/universal/NestedMultisigBuilder.sol";
+import {Simulation} from "../../script/universal/Simulation.sol";
 import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
 import {Counter} from "./Counter.sol";
 
@@ -45,7 +46,7 @@ contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {
         safe3.setup(owners3, 2, address(0), "", address(0), address(0), 0, address(0));
     }
 
-    function _postCheck() internal view override {
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
         // Check that the counter has been incremented
         uint256 counterValue = counter.count();
         require(counterValue == 1, "Counter value is not 1");


### PR DESCRIPTION
These were removed as parameters in #97. However, after looking at the changes in ethereum-optimism/superchain-ops#356, it seems simpler if they are just passed in.