### PR TITLE
Re-introduce Safe interface, and remove from function signatures

### DIFF
--- a/script/deploy/l1/SetGasLimitBuilder.sol
+++ b/script/deploy/l1/SetGasLimitBuilder.sol
@@ -45,8 +45,8 @@ abstract contract SetGasLimitBuilder is MultisigBuilder {
         return SYSTEM_CONFIG_OWNER;
     }
 
-    function _getNonce(IGnosisSafe safe) internal view override returns (uint256 nonce) {
-        nonce = safe.nonce() + _nonceOffset();
+    function _getNonce(address safe) internal view override returns (uint256 nonce) {
+        nonce = IGnosisSafe(safe).nonce() + _nonceOffset();
     }
 
     // We need to expect that the gas limit will have been updated previously in our simulation

--- a/script/universal/IGnosisSafe.sol
+++ b/script/universal/IGnosisSafe.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.10;
+
+/// @title Enum - Collection of enums used in Safe contracts.
+/// @author Richard Meissner - @rmeissner
+abstract contract Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+/// @title IGnosisSafe - Gnosis Safe Interface
+interface IGnosisSafe {
+    event AddedOwner(address owner);
+    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
+    event ChangedFallbackHandler(address handler);
+    event ChangedGuard(address guard);
+    event ChangedThreshold(uint256 threshold);
+    event DisabledModule(address module);
+    event EnabledModule(address module);
+    event ExecutionFailure(bytes32 txHash, uint256 payment);
+    event ExecutionFromModuleFailure(address indexed module);
+    event ExecutionFromModuleSuccess(address indexed module);
+    event ExecutionSuccess(bytes32 txHash, uint256 payment);
+    event RemovedOwner(address owner);
+    event SafeReceived(address indexed sender, uint256 value);
+    event SafeSetup(
+        address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler
+    );
+    event SignMsg(bytes32 indexed msgHash);
+
+    function VERSION() external view returns (string memory);
+    function addOwnerWithThreshold(address owner, uint256 _threshold) external;
+    function approveHash(bytes32 hashToApprove) external;
+    function approvedHashes(address, bytes32) external view returns (uint256);
+    function changeThreshold(uint256 _threshold) external;
+    function checkNSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, uint256 requiredSignatures)
+        external
+        view;
+    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) external view;
+    function disableModule(address prevModule, address module) external;
+    function domainSeparator() external view returns (bytes32);
+    function enableModule(address module) external;
+    function encodeTransactionData(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) external view returns (bytes memory);
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        bytes memory signatures
+    ) external payable returns (bool success);
+    function execTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (bool success);
+    function execTransactionFromModuleReturnData(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (bool success, bytes memory returnData);
+    function getChainId() external view returns (uint256);
+    function getModulesPaginated(address start, uint256 pageSize)
+        external
+        view
+        returns (address[] memory array, address next);
+    function getOwners() external view returns (address[] memory);
+    function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
+    function getThreshold() external view returns (uint256);
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) external view returns (bytes32);
+    function isModuleEnabled(address module) external view returns (bool);
+    function isOwner(address owner) external view returns (bool);
+    function nonce() external view returns (uint256);
+    function removeOwner(address prevOwner, address owner, uint256 _threshold) external;
+    function requiredTxGas(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (uint256);
+    function setFallbackHandler(address handler) external;
+    function setGuard(address guard) external;
+    function setup(
+        address[] memory _owners,
+        uint256 _threshold,
+        address to,
+        bytes memory data,
+        address fallbackHandler,
+        address paymentToken,
+        uint256 payment,
+        address paymentReceiver
+    ) external;
+    function signedMessages(bytes32) external view returns (uint256);
+    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external;
+    function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
+}

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {console} from "forge-std/console.sol";
 import {CommonBase} from "forge-std/Base.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
-import {IGnosisSafe, Enum} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
+import {IGnosisSafe, Enum} from "./IGnosisSafe.sol";
 import {Simulation} from "./Simulation.sol";
 import {Signatures} from "./Signatures.sol";
 

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -164,10 +164,7 @@ abstract contract MultisigBase is CommonBase {
         );
     }
 
-    function _execTransaction(address _safe, bytes memory _data, bytes memory _signatures)
-        internal
-        returns (bool)
-    {
+    function _execTransaction(address _safe, bytes memory _data, bytes memory _signatures) internal returns (bool) {
         return IGnosisSafe(_safe).execTransaction({
             to: MULTICALL3_ADDRESS,
             value: 0,

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -208,18 +208,13 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         calls[0] = IMulticall3.Call3({target: _signerSafe, allowFailure: false, callData: approveHashExec});
 
         // simulate the final state changes tx, so that signer can verify the final results
-        bytes memory finalExec =
-            _execTransationCalldata(_safe, _data, Signatures.genPrevalidatedSignature(_signerSafe));
+        bytes memory finalExec = _execTransationCalldata(_safe, _data, Signatures.genPrevalidatedSignature(_signerSafe));
         calls[1] = IMulticall3.Call3({target: _safe, allowFailure: false, callData: finalExec});
 
         return calls;
     }
 
-    function _overrides(address _signerSafe, address _safe)
-        internal
-        view
-        returns (Simulation.StateOverride[] memory)
-    {
+    function _overrides(address _signerSafe, address _safe) internal view returns (Simulation.StateOverride[] memory) {
         Simulation.StateOverride[] memory simOverrides = _simulationOverrides();
         Simulation.StateOverride[] memory overrides = new Simulation.StateOverride[](2 + simOverrides.length);
         overrides[0] = _safeOverrides(_signerSafe, MULTICALL3_ADDRESS);

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -62,8 +62,8 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      * their signature to a facilitator, who will execute the approval transaction for each
      * multisig (see step 2).
      */
-    function sign(IGnosisSafe _signerSafe) public {
-        IGnosisSafe nestedSafe = IGnosisSafe(_ownerSafe());
+    function sign(address _signerSafe) public {
+        address nestedSafe = _ownerSafe();
 
         // Snapshot and restore Safe nonce after simulation, otherwise the data logged to sign
         // would not match the actual data we need to sign, because the simulation
@@ -80,8 +80,8 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         _postCheck(accesses, simPayload);
 
         // Restore the original nonce.
-        vm.store(address(nestedSafe), SAFE_NONCE_SLOT, bytes32(originalNonce));
-        vm.store(address(_signerSafe), SAFE_NONCE_SLOT, bytes32(originalSignerNonce));
+        vm.store(nestedSafe, SAFE_NONCE_SLOT, bytes32(originalNonce));
+        vm.store(_signerSafe, SAFE_NONCE_SLOT, bytes32(originalSignerNonce));
 
         _printDataToSign(_signerSafe, _toArray(call));
     }
@@ -92,10 +92,9 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      * Verify the signatures generated from step 1 are valid.
      * This allow transactions to be pre-signed and stored safely before execution.
      */
-    function verify(IGnosisSafe _signerSafe, bytes memory _signatures) public view {
-        IGnosisSafe nestedSafe = IGnosisSafe(_ownerSafe());
+    function verify(address _signerSafe, bytes memory _signatures) public view {
         IMulticall3.Call3[] memory nestedCalls = _buildCalls();
-        IMulticall3.Call3 memory call = _generateApproveCall(nestedSafe, nestedCalls);
+        IMulticall3.Call3 memory call = _generateApproveCall(_ownerSafe(), nestedCalls);
         _checkSignatures(_signerSafe, _toArray(call), _signatures);
     }
 
@@ -106,10 +105,9 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      * (non-signer), once for each of the multisigs involved in the nested multisig,
      * after collecting a threshold of signatures for each multisig (see step 1).
      */
-    function approve(IGnosisSafe _signerSafe, bytes memory _signatures) public {
-        IGnosisSafe nestedSafe = IGnosisSafe(_ownerSafe());
+    function approve(address _signerSafe, bytes memory _signatures) public {
         IMulticall3.Call3[] memory nestedCalls = _buildCalls();
-        IMulticall3.Call3 memory call = _generateApproveCall(nestedSafe, nestedCalls);
+        IMulticall3.Call3 memory call = _generateApproveCall(_ownerSafe(), nestedCalls);
 
         vm.startBroadcast();
         (Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) =
@@ -126,7 +124,6 @@ abstract contract NestedMultisigBuilder is MultisigBase {
      * all of the approval transactions have been submitted onchain (see step 2).
      */
     function run() public {
-        IGnosisSafe nestedSafe = IGnosisSafe(_ownerSafe());
         IMulticall3.Call3[] memory nestedCalls = _buildCalls();
 
         // signatures is empty, because `_executeTransaction` internally collects all of the approvedHash addresses
@@ -134,7 +131,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
 
         vm.startBroadcast();
         (Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) =
-            _executeTransaction(nestedSafe, nestedCalls, signatures);
+            _executeTransaction(_ownerSafe(), nestedCalls, signatures);
         vm.stopBroadcast();
 
         _postRun(accesses, simPayload);
@@ -145,7 +142,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         return false;
     }
 
-    function _generateApproveCall(IGnosisSafe _safe, IMulticall3.Call3[] memory _calls)
+    function _generateApproveCall(address _safe, IMulticall3.Call3[] memory _calls)
         internal
         view
         returns (IMulticall3.Call3 memory)
@@ -156,13 +153,13 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         console.logBytes32(hash);
 
         return IMulticall3.Call3({
-            target: address(_safe),
+            target: _safe,
             allowFailure: false,
-            callData: abi.encodeCall(_safe.approveHash, (hash))
+            callData: abi.encodeCall(IGnosisSafe(_safe).approveHash, (hash))
         });
     }
 
-    function _simulateForSigner(IGnosisSafe _signerSafe, IGnosisSafe _safe, IMulticall3.Call3[] memory _calls)
+    function _simulateForSigner(address _signerSafe, address _safe, IMulticall3.Call3[] memory _calls)
         internal
         returns (Vm.AccountAccess[] memory, Simulation.Payload memory)
     {
@@ -184,7 +181,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         return (accesses, simPayload);
     }
 
-    function _simulateForSignerCalls(IGnosisSafe _signerSafe, IGnosisSafe _safe, bytes memory _data)
+    function _simulateForSignerCalls(address _signerSafe, address _safe, bytes memory _data)
         internal
         view
         returns (IMulticall3.Call3[] memory)
@@ -198,9 +195,9 @@ abstract contract NestedMultisigBuilder is MultisigBase {
             (
                 _toArray(
                     IMulticall3.Call3({
-                        target: address(_safe),
+                        target: _safe,
                         allowFailure: false,
-                        callData: abi.encodeCall(_safe.approveHash, (hash))
+                        callData: abi.encodeCall(IGnosisSafe(_safe).approveHash, (hash))
                     })
                 )
             )
@@ -208,17 +205,17 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         bytes memory approveHashExec = _execTransationCalldata(
             _signerSafe, approveHashData, Signatures.genPrevalidatedSignature(MULTICALL3_ADDRESS)
         );
-        calls[0] = IMulticall3.Call3({target: address(_signerSafe), allowFailure: false, callData: approveHashExec});
+        calls[0] = IMulticall3.Call3({target: _signerSafe, allowFailure: false, callData: approveHashExec});
 
         // simulate the final state changes tx, so that signer can verify the final results
         bytes memory finalExec =
-            _execTransationCalldata(_safe, _data, Signatures.genPrevalidatedSignature(address(_signerSafe)));
-        calls[1] = IMulticall3.Call3({target: address(_safe), allowFailure: false, callData: finalExec});
+            _execTransationCalldata(_safe, _data, Signatures.genPrevalidatedSignature(_signerSafe));
+        calls[1] = IMulticall3.Call3({target: _safe, allowFailure: false, callData: finalExec});
 
         return calls;
     }
 
-    function _overrides(IGnosisSafe _signerSafe, IGnosisSafe _safe)
+    function _overrides(address _signerSafe, address _safe)
         internal
         view
         returns (Simulation.StateOverride[] memory)

--- a/script/universal/Signatures.sol
+++ b/script/universal/Signatures.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import {Bytes} from "@eth-optimism-bedrock/src/libraries/Bytes.sol";
 import {LibSort} from "@solady/utils/LibSort.sol";
-import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
+import {IGnosisSafe} from "./IGnosisSafe.sol";
 
 library Signatures {
     function prepareSignatures(address _safe, bytes32 hash, bytes memory _signatures)

--- a/script/universal/Signatures.sol
+++ b/script/universal/Signatures.sol
@@ -6,7 +6,7 @@ import {LibSort} from "@solady/utils/LibSort.sol";
 import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
 
 library Signatures {
-    function prepareSignatures(IGnosisSafe _safe, bytes32 hash, bytes memory _signatures)
+    function prepareSignatures(address _safe, bytes32 hash, bytes memory _signatures)
         internal
         view
         returns (bytes memory)
@@ -17,7 +17,7 @@ library Signatures {
         _signatures = bytes.concat(prevalidatedSignatures, _signatures);
 
         // safe requires all signatures to be unique, and sorted ascending by public key
-        return sortUniqueSignatures(_signatures, hash, _safe.getThreshold(), prevalidatedSignatures.length);
+        return sortUniqueSignatures(_signatures, hash, IGnosisSafe(_safe).getThreshold(), prevalidatedSignatures.length);
     }
 
     function genPrevalidatedSignatures(address[] memory _addresses) internal pure returns (bytes memory) {
@@ -36,15 +36,16 @@ library Signatures {
         return abi.encodePacked(r, s, v);
     }
 
-    function getApprovers(IGnosisSafe _safe, bytes32 hash) internal view returns (address[] memory) {
+    function getApprovers(address _safe, bytes32 hash) internal view returns (address[] memory) {
         // get a list of owners that have approved this transaction
-        uint256 threshold = _safe.getThreshold();
-        address[] memory owners = _safe.getOwners();
+        IGnosisSafe safe = IGnosisSafe(_safe);
+        uint256 threshold = safe.getThreshold();
+        address[] memory owners = safe.getOwners();
         address[] memory approvers = new address[](threshold);
         uint256 approverIndex;
         for (uint256 i; i < owners.length; i++) {
             address owner = owners[i];
-            uint256 approved = _safe.approvedHashes(owner, hash);
+            uint256 approved = safe.approvedHashes(owner, hash);
             if (approved == 1) {
                 approvers[approverIndex] = owner;
                 approverIndex++;

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -56,8 +56,7 @@ library Simulation {
         view
         returns (StateOverride memory)
     {
-        StateOverride memory state =
-            StateOverride({contractAddress: _safe, overrides: new StorageOverride[](0)});
+        StateOverride memory state = StateOverride({contractAddress: _safe, overrides: new StorageOverride[](0)});
         state = addThresholdOverride(_safe, state);
         state = addOwnerOverride(_safe, state, _owner);
         state = addNonceOverride(_safe, state, _nonce);

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import {console} from "forge-std/console.sol";
 import {Vm} from "forge-std/Vm.sol";
-import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
+import {IGnosisSafe} from "./IGnosisSafe.sol";
 
 library Simulation {
     address internal constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -51,38 +51,38 @@ library Simulation {
         return accesses;
     }
 
-    function overrideSafeThresholdOwnerAndNonce(IGnosisSafe _safe, address _owner, uint256 _nonce)
+    function overrideSafeThresholdOwnerAndNonce(address _safe, address _owner, uint256 _nonce)
         public
         view
         returns (StateOverride memory)
     {
         StateOverride memory state =
-            StateOverride({contractAddress: address(_safe), overrides: new StorageOverride[](0)});
+            StateOverride({contractAddress: _safe, overrides: new StorageOverride[](0)});
         state = addThresholdOverride(_safe, state);
         state = addOwnerOverride(_safe, state, _owner);
         state = addNonceOverride(_safe, state, _nonce);
         return state;
     }
 
-    function addThresholdOverride(IGnosisSafe _safe, StateOverride memory _state)
+    function addThresholdOverride(address _safe, StateOverride memory _state)
         internal
         view
         returns (StateOverride memory)
     {
         // get the threshold and check if we need to override it
-        if (_safe.getThreshold() == 1) return _state;
+        if (IGnosisSafe(_safe).getThreshold() == 1) return _state;
 
         // set the threshold (slot 4) to 1
         return addOverride(_state, StorageOverride({key: bytes32(uint256(0x4)), value: bytes32(uint256(0x1))}));
     }
 
-    function addOwnerOverride(IGnosisSafe _safe, StateOverride memory _state, address _owner)
+    function addOwnerOverride(address _safe, StateOverride memory _state, address _owner)
         internal
         view
         returns (StateOverride memory)
     {
         // get the owners and check if _owner is an owner
-        address[] memory owners = _safe.getOwners();
+        address[] memory owners = IGnosisSafe(_safe).getOwners();
         for (uint256 i; i < owners.length; i++) {
             if (owners[i] == _owner) return _state;
         }
@@ -102,13 +102,13 @@ library Simulation {
         );
     }
 
-    function addNonceOverride(IGnosisSafe _safe, StateOverride memory _state, uint256 _nonce)
+    function addNonceOverride(address _safe, StateOverride memory _state, uint256 _nonce)
         internal
         view
         returns (StateOverride memory)
     {
         // get the nonce and check if we need to override it
-        if (_safe.nonce() == _nonce) return _state;
+        if (IGnosisSafe(_safe).nonce() == _nonce) return _state;
 
         // set the nonce (slot 5) to the desired value
         return addOverride(_state, StorageOverride({key: bytes32(uint256(0x5)), value: bytes32(_nonce)}));

--- a/test/universal/MultisigBuilder.t.sol
+++ b/test/universal/MultisigBuilder.t.sol
@@ -8,7 +8,7 @@ import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {Preinstalls} from "@eth-optimism-bedrock/src/libraries/Preinstalls.sol";
 import {MultisigBuilder} from "../../script/universal/MultisigBuilder.sol";
 import {Simulation} from "../../script/universal/Simulation.sol";
-import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
+import {IGnosisSafe} from "../../script/universal/IGnosisSafe.sol";
 import {Counter} from "./Counter.sol";
 
 contract MultisigBuilderTest is Test, MultisigBuilder {

--- a/test/universal/MultisigBuilder.t.sol
+++ b/test/universal/MultisigBuilder.t.sol
@@ -15,20 +15,20 @@ contract MultisigBuilderTest is Test, MultisigBuilder {
     Vm.Wallet internal wallet1 = vm.createWallet("1");
     Vm.Wallet internal wallet2 = vm.createWallet("2");
 
-    IGnosisSafe internal safe = IGnosisSafe(address(1001));
+    address internal safe = address(1001);
     Counter internal counter = new Counter(address(safe));
 
     bytes internal dataToSign =
         hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c41dcff2c17a271265df60d1612a7387110475b6fc5178add5518196db5dba6bd";
 
     function setUp() public {
-        vm.etch(address(safe), Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid));
+        vm.etch(safe, Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid));
         vm.etch(Preinstalls.MultiCall3, Preinstalls.getDeployedCode(Preinstalls.MultiCall3, block.chainid));
 
         address[] memory owners = new address[](2);
         owners[0] = wallet1.addr;
         owners[1] = wallet2.addr;
-        safe.setup(owners, 2, address(0), "", address(0), address(0), 0, address(0));
+        IGnosisSafe(safe).setup(owners, 2, address(0), "", address(0), address(0), 0, address(0));
     }
 
     function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {

--- a/test/universal/NestedMultisigBuilder.t.sol
+++ b/test/universal/NestedMultisigBuilder.t.sol
@@ -8,7 +8,7 @@ import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {Preinstalls} from "@eth-optimism-bedrock/src/libraries/Preinstalls.sol";
 import {NestedMultisigBuilder} from "../../script/universal/NestedMultisigBuilder.sol";
 import {Simulation} from "../../script/universal/Simulation.sol";
-import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
+import {IGnosisSafe} from "../../script/universal/IGnosisSafe.sol";
 import {Counter} from "./Counter.sol";
 
 contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {

--- a/test/universal/NestedMultisigBuilder.t.sol
+++ b/test/universal/NestedMultisigBuilder.t.sol
@@ -15,9 +15,9 @@ contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {
     Vm.Wallet internal wallet1 = vm.createWallet("1");
     Vm.Wallet internal wallet2 = vm.createWallet("2");
 
-    IGnosisSafe internal safe1 = IGnosisSafe(address(1001));
-    IGnosisSafe internal safe2 = IGnosisSafe(address(1002));
-    IGnosisSafe internal safe3 = IGnosisSafe(address(1003));
+    address internal safe1 = address(1001);
+    address internal safe2 = address(1002);
+    address internal safe3 = address(1003);
     Counter internal counter = new Counter(address(safe3));
 
     bytes internal dataToSign1 =
@@ -27,23 +27,23 @@ contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {
 
     function setUp() public {
         bytes memory safeCode = Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid);
-        vm.etch(address(safe1), safeCode);
-        vm.etch(address(safe2), safeCode);
-        vm.etch(address(safe3), safeCode);
+        vm.etch(safe1, safeCode);
+        vm.etch(safe2, safeCode);
+        vm.etch(safe3, safeCode);
         vm.etch(Preinstalls.MultiCall3, Preinstalls.getDeployedCode(Preinstalls.MultiCall3, block.chainid));
 
         address[] memory owners1 = new address[](1);
         owners1[0] = wallet1.addr;
-        safe1.setup(owners1, 1, address(0), "", address(0), address(0), 0, address(0));
+        IGnosisSafe(safe1).setup(owners1, 1, address(0), "", address(0), address(0), 0, address(0));
 
         address[] memory owners2 = new address[](1);
         owners2[0] = wallet2.addr;
-        safe2.setup(owners2, 1, address(0), "", address(0), address(0), 0, address(0));
+        IGnosisSafe(safe2).setup(owners2, 1, address(0), "", address(0), address(0), 0, address(0));
 
         address[] memory owners3 = new address[](2);
-        owners3[0] = address(safe1);
-        owners3[1] = address(safe2);
-        safe3.setup(owners3, 2, address(0), "", address(0), address(0), 0, address(0));
+        owners3[0] = safe1;
+        owners3[1] = safe2;
+        IGnosisSafe(safe3).setup(owners3, 2, address(0), "", address(0), address(0), 0, address(0));
     }
 
     function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {


### PR DESCRIPTION
#102 removed the `IGnosisSafe` due to incompatibilities with optimism's interface.

This PR reverts that PR, and removes the `IGnosisSafe` from any function parameters (replacing with `address`) so we can be maximally compatible.