### PR TITLE
[NestedMultisigBuilder] Don't override signerSafe owner

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -190,6 +190,9 @@ abstract contract MultisigBase is CommonBase {
         returns (Simulation.StateOverride memory)
     {
         uint256 _nonce = _getNonce(_safe);
+        if (_owner == address(0)) {
+            return Simulation.overrideSafeThresholdAndNonce(_safe, _nonce);
+        }
         return Simulation.overrideSafeThresholdOwnerAndNonce(_safe, _owner, _nonce);
     }
 

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -218,7 +218,7 @@ abstract contract NestedMultisigBuilder is MultisigBase {
         Simulation.StateOverride[] memory simOverrides = _simulationOverrides();
         Simulation.StateOverride[] memory overrides = new Simulation.StateOverride[](2 + simOverrides.length);
         overrides[0] = _safeOverrides(_signerSafe, MULTICALL3_ADDRESS);
-        overrides[1] = _safeOverrides(_safe, msg.sender);
+        overrides[1] = _safeOverrides(_safe, address(0));
         for (uint256 i = 0; i < simOverrides.length; i++) {
             overrides[i + 2] = simOverrides[i];
         }

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -51,6 +51,17 @@ library Simulation {
         return accesses;
     }
 
+    function overrideSafeThresholdAndNonce(address _safe, uint256 _nonce)
+        public
+        view
+        returns (StateOverride memory)
+    {
+        StateOverride memory state = StateOverride({contractAddress: _safe, overrides: new StorageOverride[](0)});
+        state = addThresholdOverride(_safe, state);
+        state = addNonceOverride(_safe, state, _nonce);
+        return state;
+    }
+
     function overrideSafeThresholdOwnerAndNonce(address _safe, address _owner, uint256 _nonce)
         public
         view

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -51,11 +51,7 @@ library Simulation {
         return accesses;
     }
 
-    function overrideSafeThresholdAndNonce(address _safe, uint256 _nonce)
-        public
-        view
-        returns (StateOverride memory)
-    {
+    function overrideSafeThresholdAndNonce(address _safe, uint256 _nonce) public view returns (StateOverride memory) {
         StateOverride memory state = StateOverride({contractAddress: _safe, overrides: new StorageOverride[](0)});
         state = addThresholdOverride(_safe, state);
         state = addNonceOverride(_safe, state, _nonce);


### PR DESCRIPTION
#97 introduced a small bug where the outer safe owner was unnecessarily overridden in the simulation. This owner override did not exist prior to this refactor, and is not needed because the simulation doesn't simulate the approval, but rather the inner nested sig tx action (i.e. what the outer signer sig is actually approving).

This PR removes this owner override. Fixes this issue: https://github.com/ethereum-optimism/superchain-ops/pull/363#issuecomment-2455912210